### PR TITLE
Change to the display order of Contacts Table Columns

### DIFF
--- a/client/src/dashboard/pages/contacts/Contacts.jsx
+++ b/client/src/dashboard/pages/contacts/Contacts.jsx
@@ -31,9 +31,9 @@ function Contacts() {
   const columns = [
     { title: 'First Name', field: 'first_name' },
     { title: 'Last Name', field: 'last_name' },
+    { title: 'Organization', field: 'organizationName' },
     { title: 'Email', field: 'email' },
     { title: 'Phone Number', field: 'phone' },
-    { title: 'Organization', field: 'organizationName' },
     { title: 'Extension', field: 'exten' },
   ];
 


### PR DESCRIPTION
Moved Organization to be before contact info and place phone number and extension next to each other.